### PR TITLE
Add GitHub Copilot CLI to Brewfile and update installation instructions

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -7,6 +7,7 @@ brew "uv"
 brew "gh"
 brew "zsh-syntax-highlighting"
 
+cask "copilot-cli"
 cask "visual-studio-code"
 cask "docker-desktop"
 cask "iterm2"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This will install and configure:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) via Homebrew Cask in Bundle
 - [iTerm2](https://iterm2.com/) via Homebrew Cask in Bundle
 - `zsh-syntax-highlighting` via Homebrew Bundle
-- [GitHub Copilot CLI](https://githubnext.com/projects/copilot-cli) via `gh` extension
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli) via Homebrew Cask in Bundle
 - Git via Xcode Command Line Tools
 
 Homebrew-managed software is defined in [Brewfile](Brewfile) and installed with:

--- a/setup.sh
+++ b/setup.sh
@@ -34,14 +34,3 @@ fi
 
 # Install formulae and casks listed in Brewfile.
 brew bundle --file="$BASEDIR/Brewfile"
-
-# Install GitHub Copilot CLI extension
-if command -v gh > /dev/null 2>&1
-then
-    if gh extension list 2>/dev/null | grep -q 'gh-copilot'
-    then
-        gh extension upgrade gh-copilot 2>/dev/null || true
-    else
-        gh extension install github/gh-copilot 2>/dev/null || true
-    fi
-fi

--- a/zshrc
+++ b/zshrc
@@ -146,12 +146,6 @@ fi
 # Configuration for Python via uv
 add_path "$HOME/.local/bin"
 
-# GitHub Copilot CLI alias
-if command -v gh > /dev/null 2>&1
-then
-  eval "$(gh copilot alias -- zsh)" 2>/dev/null || true
-fi
-
 # Enable zsh-syntax-highlighting (must be sourced at the end)
 ZSH_SYNTAX_HIGHLIGHTING="$(brew --prefix 2>/dev/null)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 [ -f "$ZSH_SYNTAX_HIGHLIGHTING" ] && source "$ZSH_SYNTAX_HIGHLIGHTING"


### PR DESCRIPTION
Include GitHub Copilot CLI in the Brewfile for easier installation via Homebrew Cask. Update the installation instructions to reflect this change and remove the previous method of installation through the `gh` extension.