### PR TITLE
Add ripgrep to Brewfile and update README with installation details

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,7 @@
 
 brew "go"
 brew "golangci-lint"
+brew "ripgrep"
 brew "fnm"
 brew "uv"
 brew "gh"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This will install and configure:
 - [VS Code](https://code.visualstudio.com/) via Homebrew Cask in Bundle
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) via Homebrew Cask in Bundle
 - [iTerm2](https://iterm2.com/) via Homebrew Cask in Bundle
+- [ripgrep](https://github.com/BurntSushi/ripgrep) via Homebrew Bundle for fast recursive search with `rg`
 - `zsh-syntax-highlighting` via Homebrew Bundle
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) via Homebrew Cask in Bundle
 - Git via Xcode Command Line Tools
@@ -50,4 +51,10 @@ brew bundle dump --force --file=Brewfile
 
 # Uninstall packages not listed in Brewfile
 brew bundle cleanup --file=Brewfile --force
+```
+
+Useful local search command once the bundle is installed:
+
+```sh
+rg "TODO" .
 ```


### PR DESCRIPTION
Include ripgrep in the Brewfile for installation via Homebrew and update the README to provide installation details and usage examples.