### PR TITLE
Add go-task to Brewfile and update Taskfile and README

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -6,6 +6,7 @@ brew "ripgrep"
 brew "fnm"
 brew "uv"
 brew "gh"
+brew "go-task"
 brew "zsh-syntax-highlighting"
 
 cask "copilot-cli"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This will install and configure:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) via Homebrew Cask in Bundle
 - [iTerm2](https://iterm2.com/) via Homebrew Cask in Bundle
 - [ripgrep](https://github.com/BurntSushi/ripgrep) via Homebrew Bundle for fast recursive search with `rg`
+- [Task](https://taskfile.dev/) via Homebrew Bundle for running tasks from [Taskfile.yml](Taskfile.yml)
 - `zsh-syntax-highlighting` via Homebrew Bundle
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) via Homebrew Cask in Bundle
 - [Codex](https://developers.openai.com/codex/) via Homebrew Cask in Bundle
@@ -38,6 +39,8 @@ Homebrew-managed software is defined in [Brewfile](Brewfile) and installed with:
 ```sh
 brew bundle --file=Brewfile
 ```
+
+Common project commands are defined in [Taskfile.yml](Taskfile.yml) and run with `task`.
 
 ## Maintenance
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,7 @@ tasks:
       - brew list --versions fnm
       - brew list --versions uv
       - brew list --versions gh
+      - brew list --versions go-task
       - brew list --versions zsh-syntax-highlighting
       - brew list --cask --versions copilot-cli
       - brew list --cask --versions visual-studio-code


### PR DESCRIPTION
Include go-task in the Brewfile for installation and update the README to reflect its usage in the project. Additionally, ensure the Taskfile includes commands for managing go-task.